### PR TITLE
Stack pointer starts at $00 and fix push/pull order of operations

### DIFF
--- a/NesEmulator.Tests/CPUTests/OpcodeImplementations/JSR.cs
+++ b/NesEmulator.Tests/CPUTests/OpcodeImplementations/JSR.cs
@@ -56,8 +56,8 @@ namespace NesEmulator.UnitTests.CPUTests.OpcodeImplementations
                 byte lowByte = (byte)(expectedPushValue % 256);
                 byte highByte = (byte)(expectedPushValue >> 8);
 
-                ushort highPushAddress = sut.StackPointer.Plus(-1);
-                ushort lowPushAddress = sut.StackPointer.Plus(-2);
+                ushort highPushAddress = sut.StackPointer;
+                ushort lowPushAddress = sut.StackPointer.Plus(-1);
                 
                 sut.Step();
 

--- a/NesEmulator.Tests/CPUTests/OpcodeImplementations/PHA.cs
+++ b/NesEmulator.Tests/CPUTests/OpcodeImplementations/PHA.cs
@@ -93,7 +93,7 @@ namespace NesEmulator.UnitTests.CPUTests.OpcodeImplementations
                 A.CallTo(() => _memory.Read(sut.InstructionPointer))
                     .Returns(_op.Value);
 
-                var sp = sut.StackPointer.Plus(-1);
+                var sp = sut.StackPointer;
 
                 sut.Step();
 

--- a/NesEmulator.Tests/CPUTests/OpcodeImplementations/PHP.cs
+++ b/NesEmulator.Tests/CPUTests/OpcodeImplementations/PHP.cs
@@ -46,7 +46,7 @@ namespace NesEmulator.UnitTests.CPUTests.OpcodeImplementations
                 A.CallTo(() => _memory.Read(sut.InstructionPointer))
                     .Returns(_op.Value);
 
-                var sp = sut.StackPointer.Plus(-1);
+                var sp = sut.StackPointer;
 
                 sut.Step();
 

--- a/NesEmulator.Tests/CPUTests/OpcodeImplementations/PLA.cs
+++ b/NesEmulator.Tests/CPUTests/OpcodeImplementations/PLA.cs
@@ -48,7 +48,7 @@ namespace NesEmulator.UnitTests.CPUTests.OpcodeImplementations
 
                 A.CallTo(() => _memory.Read(sut.InstructionPointer))
                     .Returns(_op.Value);
-                A.CallTo(() => _memory.Read(sut.StackPointer))
+                A.CallTo(() => _memory.Read(sut.StackPointer.Plus(1)))
                     .Returns(value);
 
                 sut.Step();
@@ -69,7 +69,7 @@ namespace NesEmulator.UnitTests.CPUTests.OpcodeImplementations
 
                 A.CallTo(() => _memory.Read(sut.InstructionPointer))
                     .Returns(_op.Value);
-                A.CallTo(() => _memory.Read(sut.StackPointer))
+                A.CallTo(() => _memory.Read(sut.StackPointer.Plus(1)))
                     .Returns(value);
 
                 sut.Step();
@@ -117,7 +117,7 @@ namespace NesEmulator.UnitTests.CPUTests.OpcodeImplementations
 
                 A.CallTo(() => _memory.Read(sut.InstructionPointer))
                     .Returns(_op.Value);
-                A.CallTo(() => _memory.Read(sut.StackPointer))
+                A.CallTo(() => _memory.Read(sut.StackPointer.Plus(1)))
                     .Returns(value);
 
                 sut.Step();

--- a/NesEmulator.Tests/CPUTests/OpcodeImplementations/PLP.cs
+++ b/NesEmulator.Tests/CPUTests/OpcodeImplementations/PLP.cs
@@ -52,7 +52,7 @@ namespace NesEmulator.UnitTests.CPUTests.OpcodeImplementations
 
                 A.CallTo(() => _memory.Read(sut.InstructionPointer))
                     .Returns(_op.Value);
-                A.CallTo(() => _memory.Read(sut.StackPointer))
+                A.CallTo(() => _memory.Read(sut.StackPointer.Plus(1)))
                     .Returns(value);
 
                 sut.Step();

--- a/NesEmulator.Tests/CPUTests/OpcodeImplementations/RTI.cs
+++ b/NesEmulator.Tests/CPUTests/OpcodeImplementations/RTI.cs
@@ -53,7 +53,7 @@ namespace NesEmulator.UnitTests.CPUTests.OpcodeImplementations
                 A.CallTo(() => _memory.Read(sut.InstructionPointer))
                     .Returns(_op.Value);
 
-                A.CallTo(() => _memory.Read(sut.StackPointer))
+                A.CallTo(() => _memory.Read(sut.StackPointer.Plus(1)))
                     .Returns(storedStatus);
                 
                 sut.Step();
@@ -65,8 +65,8 @@ namespace NesEmulator.UnitTests.CPUTests.OpcodeImplementations
             public void RestoresInstructionPointerFromStack()
             {
                 ushort stackStart = 0x0134;
-                ushort lowByteAddr = stackStart.Plus(1);
-                ushort highByteAddr = stackStart.Plus(2);
+                ushort lowByteAddr = stackStart.Plus(2);
+                ushort highByteAddr = stackStart.Plus(3);
 
                 byte low = 0x47;
                 byte high = 0xE4;

--- a/NesEmulator.Tests/CPUTests/OpcodeImplementations/RTS.cs
+++ b/NesEmulator.Tests/CPUTests/OpcodeImplementations/RTS.cs
@@ -46,9 +46,9 @@ namespace NesEmulator.UnitTests.CPUTests.OpcodeImplementations
 
                 A.CallTo(() => _memory.Read(sut.InstructionPointer))
                     .Returns(_op.Value);
-                A.CallTo(() => _memory.Read(sut.StackPointer))
-                    .Returns(low);
                 A.CallTo(() => _memory.Read(sut.StackPointer.Plus(1)))
+                    .Returns(low);
+                A.CallTo(() => _memory.Read(sut.StackPointer.Plus(2)))
                     .Returns(high);
                 
                 sut.Step();

--- a/NesEmulator.Tests/CPUTests/PowerOnState.cs
+++ b/NesEmulator.Tests/CPUTests/PowerOnState.cs
@@ -93,13 +93,13 @@ namespace NesEmulator.UnitTests.CPUTests
         }
 
         [Fact]
-        public void WhenPowerOn_StackPointerValueIs0x0200()
+        public void WhenPowerOn_StackPointerValueIs0x0100()
         {
             var sut = CreateSut();
 
             sut.Power();
 
-            sut.StackPointer.Should().Be(0x0200);
+            sut.StackPointer.Should().Be(0x0100);
         }
 
         [Fact]

--- a/NesEmulator/Processor/CPU.cs
+++ b/NesEmulator/Processor/CPU.cs
@@ -45,7 +45,7 @@ namespace NesEmulator.Processor
                 Accumulator = 0;
                 IndexX = 0;
                 IndexY = 0;
-                StackPointer = MemoryMap.Ram;
+                StackPointer = MemoryMap.Stack;
                 ElapsedCycles = 0;
                 Status = StatusFlags.InterruptDisable | StatusFlags.Bit5;
 
@@ -133,17 +133,16 @@ namespace NesEmulator.Processor
 
         private void Push(byte value)
         {
+            _memory.Write(StackPointer, value);
             if (--StackPointer < MemoryMap.Stack)
                 StackPointer += 0x0100;
-            _memory.Write(StackPointer, value);
         }
 
         private byte Pop()
         {
-            byte value = _memory.Read(StackPointer);
             if (++StackPointer == MemoryMap.Ram)
                 StackPointer = MemoryMap.Stack;
-            return value;
+            return _memory.Read(StackPointer);;
         }
 
         #region UnitTestHelpers


### PR DESCRIPTION
Fixes #20

SP points at available memory address
Push writes, then decrements
Pop increments, then reads

3 Dummy writes on startup for reset interrupt. SP starts as $00 and underflows, coming to rest at $FD